### PR TITLE
remove extra prints

### DIFF
--- a/R/yhatR.R
+++ b/R/yhatR.R
@@ -436,8 +436,6 @@ set.model.require <- function() {
   imports <- yhat$dependencies$importName
   yhat$model.require <- function() {
     for (pkg in imports) {
-      print("dependencies")
-      print(name)
       library(pkg, character.only = TRUE)
     }
   }
@@ -532,11 +530,8 @@ yhat.deploy <- function(model_name, packages=c(), confirm=TRUE, custom_image=NUL
     all_objects <- yhat.ls()
     # Consolidate local environment with global one
     deployEnv <- new.env(parent = emptyenv())
-    print("I AM HERE")
     deployEnv$model.require <- yhat$model.require
     for (obj in all_objects) {
-      print("obj")
-      print(obj)
       deployEnv[[obj]] <- globalenv()[[obj]]
     }
     # if model.transform is not provided give it a default value
@@ -566,8 +561,6 @@ yhat.deploy <- function(model_name, packages=c(), confirm=TRUE, custom_image=NUL
     }
 
     dependencies <- yhat$dependencies[yhat$dependencies$install,]
-    print("your dependencies")
-    print(yhat$dependencies[yhat$dependencies$install,])
 
     err.msg <- paste("Could not connect to ScienceOps. Please ensure that your",
                      "specified server is online. Contact info [at] yhathq [dot] com",


### PR DESCRIPTION
I found a couple extra prints when I was testing the latest client.

```
[1] "I AM HERE"
[1] "obj"
[1] "expectedResult"
[1] "obj"
[1] "makeRegionComparable"
[1] "obj"
[1] "model.predict"
objects detected
                  name      size
1        model.require   0 bytes
2       expectedResult 136 bytes
3 makeRegionComparable     11 Kb
4        model.predict    7.2 Kb
5      model.transform   0 bytes

Model will be deployed with the following dependencies:
      name  src version install
1    yhatr CRAN  0.15.1    TRUE
2 jsonlite CRAN     1.4    TRUE
3     plyr CRAN   1.8.4    TRUE
4    rjson CRAN  0.2.15    TRUE
5     httr CRAN   1.2.1    TRUE
6  stringr CRAN   1.1.0    TRUE
Are you sure you want to deploy? y/n y
[1] "your dependencies"
      name importName  src version install
1    yhatr      yhatr CRAN  0.15.1    TRUE
2 jsonlite   jsonlite CRAN     1.4    TRUE
3     plyr       plyr CRAN   1.8.4    TRUE
4    rjson      rjson CRAN  0.2.15    TRUE
5     httr       httr CRAN   1.2.1    TRUE
6  stringr    stringr CRAN   1.1.0    TRUE
deployment successful
```